### PR TITLE
Add last commit date displayed in time ago format

### DIFF
--- a/themes/jamstackthemes/assets/js/scripts.js
+++ b/themes/jamstackthemes/assets/js/scripts.js
@@ -13,3 +13,7 @@ document.addEventListener("DOMContentLoaded", function() {
     placement: "top-end"
   });
 });
+
+jQuery(document).ready(function() {
+  jQuery("time.timeago").timeago();
+});

--- a/themes/jamstackthemes/layouts/_default/baseof.html
+++ b/themes/jamstackthemes/layouts/_default/baseof.html
@@ -42,10 +42,12 @@
   {{ $mixitupMultiFilter := resources.Get "js/libs/mixitup-multifilter.js" }}
   {{ $popper := resources.Get "js/libs/popper.min.js" }}
   {{ $tooltip := resources.Get "js/libs/tippy.min.js" }}
+  {{ $jquery := resources.Get "js/libs/jquery-3.4.1.min.js" }}
+  {{ $timeago := resources.Get "js/libs/jquery.timeago.js" }}
   {{ $scripts := resources.Get "js/scripts.js" }}
   {{ $analytics := resources.Get "js/analytics.js" }}
 
-  {{ $js := slice $mixitup $mixitupMultiFilter $popper $tooltip $scripts $analytics | resources.Concat "js/bundle.js" }}
+  {{ $js := slice $mixitup $mixitupMultiFilter $popper $tooltip $jquery $timeago $scripts $analytics | resources.Concat "js/bundle.js" }}
   
   {{ if .Site.IsServer }}
   <script type="text/javascript" src="{{ $js.RelPermalink }}"></script>

--- a/themes/jamstackthemes/layouts/partials/last-commit.html
+++ b/themes/jamstackthemes/layouts/partials/last-commit.html
@@ -1,3 +1,4 @@
 <div class="last-commit">
-  last commit {{ dateFormat "Jan 2, 2006" .last_commit }}
+  last commit {{ dateFormat "Jan 2, 2006" .last_commit }}<br/>
+  (<time class="timeago" datetime="{{ dateFormat "2006-01-02T15:04:05Z07:00" .last_commit }}">...</time>)
 </div>


### PR DESCRIPTION
Added jQuery and timeago libraries and updated display of last commit in the partial that makes up the theme display to also display the time ago format.

Fixes #12.