### PR TITLE
Fix build error hugo v0.59.0

### DIFF
--- a/themes/jamstackthemes/layouts/index.rss.xml
+++ b/themes/jamstackthemes/layouts/index.rss.xml
@@ -13,7 +13,11 @@
     {{ with .OutputFormats.Get "RSS" }}
         {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range .Pages.ByLastmod }}
+
+    {{ $themes := (where .Site.RegularPages "Type" "theme") }}
+    {{ $themes := (where $themes ".Params.disabled" "!=" true) }}
+
+    {{ range sort $themes "Lastmod" "desc" }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
Fixes #33

I think the existing query was pulling in non-theme pages, causing a build error when looking for the `.Params.github`.

I updated using the query from index.html: https://github.com/stackbithq/jamstackthemes/blob/0fbdcd73a885478ed2088e127d56190f83c97485/themes/jamstackthemes/layouts/index.html#L18-L19