### PR TITLE
Rewrite of scrub-themes script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "build": "node ./generate-github.js && node ./capture-screenshots.js && node ./generate-thumbnails.js && hugo",
     "generate-github": "node ./generate-github.js",
     "capture-screenshots": "node ./capture-screenshots.js",
-    "generate-thumbnails": "node ./generate-thumbnails.js"
+    "generate-thumbnails": "node ./generate-thumbnails.js",
+    "scrub-themes": "node ./scub-themes.js"
   },
   "dependencies": {
     "axios": "^0.19.0",


### PR DESCRIPTION
Script now adds the following to a theme's front matter:
- Add a stale flag if no commits in past year
- Add github branch (if missing)

Added scrub-themes to scripts in package.json.

Fixes #42


Notes on testing:
I did some manual testing using the following test scenarios:

Test 1: Theme's front matter has an existing `github_branch` key specified
Expected result: should not modify file
File used: `content/theme/stackbit-theme-vanilla-gatsby.md`

Test 2: Theme's front matter does not have a `github_branch` key specified
Expected result: should add `github_branch: master` 
File used:	`content/theme/stackbit-theme-ampersand.md` (Note: _at the time of my testing `master` was this repo's default branch_)

Test 3: Theme's front matter has no `stale` key
Expected result: should add `stale: true`
File used: `content/theme/solar-theme-jekyll.md` (Note: _at the time of my testing this was a stale repo_)

Test 4: Theme's front matter has an existing old `stale` key set 
Expected result: should remove the `stale: false` entry and add an entry for `stale: true`
Manual setup: add `stale: false` to file before testing
File used: `content/theme/pelican-smoothie.md` (Note: _at the time of my testing this was a stale repo_)

Test 5: Theme's front matter has an existing `stale` key set 
Expected result: Should remove the `stale: true` entry and add an entry for `stale: false`
Manual setup: add `stale: true` to file before testing
File used: `content/theme/stackbit-theme-archetype.md` (Note: _at the time of my testing this **was not** a stale repo_)

Note: _For tests 3-5 a github_branch is also added because those theme files lacked an explicit github_branch key in the front matter._

All of the above tests were performed and passed as per the expected results before I submitted the PR

Here's what you can use to replicate my testing if you'd like to before merging:
```
# reset theme files to checked in versions (if needed)
git checkout -- content/theme/*

# Test 4 setup: add stale: false
sed -i '/title:/a stale: false' content/theme/pelican-smoothie.md

# Test 5 setup: add stale: true
sed -i '/title:/a stale: true' content/theme/stackbit-theme-archetype.md

# backup theme files for comparison after test
cp content/theme/stackbit-theme-vanilla-gatsby.md content/theme/stackbit-theme-vanilla-gatsby.md.bak
cp content/theme/stackbit-theme-ampersand.md content/theme/stackbit-theme-ampersand.md.bak
cp content/theme/solar-theme-jekyll.md content/theme/solar-theme-jekyll.md.bak
cp content/theme/pelican-smoothie.md content/theme/pelican-smoothie.md.bak
cp content/theme/stackbit-theme-archetype.md content/theme/stackbit-theme-archetype.md.bak

# Execute script under test
node scrub-themes.js

# Test 1 Result: Should be no differences
diff -s content/theme/stackbit-theme-vanilla-gatsby.md content/theme/stackbit-theme-vanilla-gatsby.md.bak

# Test 2 Result: Should add "github_branch: master"
diff -s content/theme/stackbit-theme-ampersand.md content/theme/stackbit-theme-ampersand.md.bak

# Test 3 Result: Should add `stale: true`
diff -s content/theme/solar-theme-jekyll.md content/theme/solar-theme-jekyll.md.bak

# Test 4 Result: Should remove the `stale: false` entry and add an entry for `stale: true`
diff -s content/theme/pelican-smoothie.md content/theme/pelican-smoothie.md.bak

# Test 5 Result: Should remove the `stale: true` entry and add an entry for `stale: false`
diff -s content/theme/stackbit-theme-archetype.md content/theme/stackbit-theme-archetype.md.bak

# Cleanup backup files
rm content/theme/stackbit-theme-vanilla-gatsby.md.bak
rm content/theme/stackbit-theme-ampersand.md.bak
rm content/theme/solar-theme-jekyll.md.bak
rm content/theme/pelican-smoothie.md.bak
rm content/theme/stackbit-theme-archetype.md.bak
```