### PR TITLE
Theme Submission: jekyll-theme-console

### DIFF
--- a/content/theme/jekyll-theme-console.md
+++ b/content/theme/jekyll-theme-console.md
@@ -3,7 +3,6 @@ title: "jekyll-theme-console"
 github: https://github.com/b2a3e8/jekyll-theme-console
 demo: https://b2a3e8.github.io/jekyll-theme-console/
 author: b2a3e8
-draft: true
 ssg:
   - Jekyll
 cms:


### PR DESCRIPTION
Hi, jekyll-theme-console is already present in your repo, but it is not shown on your site. I assume removing `draft: true` will fix that.