### PR TITLE
Fix invisible text on button

### DIFF
--- a/themes/jamstackthemes/assets/scss/_theme-detail.scss
+++ b/themes/jamstackthemes/assets/scss/_theme-detail.scss
@@ -37,6 +37,7 @@
   .theme-detail-buttons {
     margin-top: 20px;
     a {
+      @extend .button;
       display: inline-block;
     }
   }


### PR DESCRIPTION
### Description
Link with class `.button` in [theme detail](https://github.com/stackbithq/jamstackthemes/blob/e89cc939d6a5920b769a6324f00ab0feeafaa09b/themes/jamstackthemes/layouts/_default/single.html#L33-L34) using `$primary` color as same as its background color which causes the button text becomes invisible. I think the actual `.button` class color overwritten by [this](https://github.com/stackbithq/jamstackthemes/blob/e89cc939d6a5920b769a6324f00ab0feeafaa09b/themes/jamstackthemes/assets/scss/_link.scss#L3)

### Screenshot
![](https://user-images.githubusercontent.com/33394747/75123889-07188f80-56de-11ea-844a-389bb8eb335c.png)