### PR TITLE
Theme Submission: jekyll-theme-yat

### DIFF
--- a/content/theme/jekyll-theme-yat.md
+++ b/content/theme/jekyll-theme-yat.md
@@ -1,0 +1,59 @@
+---
+title: Yet Another Theme (YAT)
+github: https://github.com/jeffreytse/jekyll-theme-yat
+demo: https://jeffreytse.github.io/jekyll-theme-yat/
+author: Jeffrey Tse
+date: 2020-09-01T00:00:00.000Z
+github_branch: master
+ssg:
+  - Jekyll
+cms:
+  - No Cms
+archetype:
+  - Blog
+  - Business
+  - Multi Purpose
+description: >-
+  🎨 Yet another theme for elegant writers with modern flat style.
+stale: false
+---
+
+## What's new?
+
+🎨 Yet another theme for elegant writers with modern flat style.
+
+
+Hey, nice to meet you, you found this [Jekyll][jekyll] theme. Here the yet
+another theme is a modern theme, and it's quiet clear, clean and neat for
+writers and posts. It always helps us focus on the **content** and the
+**functions**.
+
+## Features
+
+- Full layouts `home`, `post`, `tags`, `archive` and `about`.
+- Uses font awesome 5 for icons.
+- Beautiful Syntax Highlight using [hilight.js][hilight-js].
+- RSS support using [Jekyll Feed][jekyll-feed] gem.
+- Optimized for search engines using [Jekyll Seo Tag][jekyll-seo-tag] gem.
+- Sitemap support using [Jekyll Sitemap][jekyll-sitemap] gem.
+- Complex and flexible table support using [jekyll-spaceship][jekyll-spaceship] gem.
+- MathJAX and LaTeX optional support using [jekyll-spaceship][jekyll-spaceship] gem.
+- Media (Youtube, Spotify, etc.) support using [jekyll-spaceship][jekyll-spaceship] gem.
+- Diagram (PlantUML, Mermaid) support using [jekyll-spaceship][jekyll-spaceship] gem.
+- Google Translation support.
+- New post tag support.
+
+## Others
+
+For more info checkout github repository [jeffreytse/jekyll-theme-yat][yat-git-repo].  
+Also, visit the live [demo][yat-live-demo] site for the theme.
+
+<!-- External links -->
+[jekyll]: https://jekyllrb.com/
+[yat-git-repo]: https://github.com/jeffreytse/jekyll-theme-yat/
+[yat-live-demo]: https://jeffreytse.github.io/jekyll-theme-yat/
+[jekyll-spaceship]: https://github.com/jeffreytse/jekyll-spaceship
+[jekyll-seo-tag]: https://github.com/jekyll/jekyll-seo-tag
+[jekyll-sitemap]: https://github.com/jekyll/jekyll-sitemap
+[jekyll-feed]: https://github.com/jekyll/jekyll-feed
+[hilight-js]: https://github.com/highlightjs/highlight.js


### PR DESCRIPTION
Add Jekyll template [jekyll-theme-yat](https://github.com/jeffreytse/jekyll-theme-yat).

:art: Yet another theme for elegant writers with modern flat style.

Thanks for creating [jamstackthemes.dev](https://jamstackthemes.dev) :)