### PR TITLE
Fix Gatsby Kontent starter links

### DIFF
--- a/content/theme/gatsby-starter-kontent.md
+++ b/content/theme/gatsby-starter-kontent.md
@@ -1,7 +1,7 @@
 ---
 title: Gatsby Starter Kentico Kontent
-github: 'https://github.com/Kentico/gatsby-starter-kentico-cloud'
-demo: 'https://gatsby-starter-kentico-cloud.netlify.com/'
+github: 'https://github.com/Kentico/gatsby-starter-kontent'
+demo: 'https://gatsby-starter-kontent.netlify.app'
 author: Kentico
 ssg:
   - Gatsby
@@ -11,6 +11,4 @@ date: 2018-08-17T10:25:38.000Z
 github_branch: master
 description: Gatsby starter site with Kentico Kontent.
 stale: false
-disabled: true
-disabled_reason: demo url not found
 ---


### PR DESCRIPTION
Fix "Gatsby Starter Kentico Kontent" properties caused by rebranding:
* Repo URL
* Demo URL