### PR TITLE
Adding CyberTermX Jekyll Theme

### DIFF
--- a/content/theme/CyberTermX.md
+++ b/content/theme/CyberTermX.md
@@ -1,0 +1,30 @@
+---
+title: "CyberTermX"
+github: https://github.com/Writeup-DB/CyberTermX
+demo: https://cybertermx.writeup-db.com/
+author: touhidshaikh (Writeup-DB)
+date: 2026-07-11
+ssg:
+  - Jekyll
+cms:
+  - No CMS
+css:
+  - Tailwind 
+archetype:
+  - Portfolio
+  - Resume
+description: A terminal-themed, hacker-aesthetic Jekyll portfolio designed specifically for cybersecurity professionals, exploit developers, and bug bounty hunters.
+---
+
+# CyberTermX Theme (Jekyll)
+
+A terminal-themed, hacker-aesthetic Jekyll portfolio designed specifically for cybersecurity professionals, exploit developers, and bug bounty hunters. This theme is 100% dynamic—you do not need to touch any HTML to update your portfolio, as everything is managed through simple YAML configuration files.
+
+## Features
+
+* **Hacker Aesthetic:** Matrix background, CRT scanlines, and neon-terminal UI built with Tailwind CSS.  
+* **Fully Configurable:** Update your identity, skills, projects, and CVEs strictly through `_config.yml` and the `_data/` directory.  
+* **Interactive Terminal:** A working web-based shell that visitors can use to run commands (`whoami`, `ls`, `neofetch`, `crack`, `hack`, etc.).  
+* **Dynamic RSS Integration:** Automatically pulls your latest blog posts from your WordPress site via the rss2json API.  
+* **Easter Eggs:** Hidden commands, Konami code integration, and cinematic "Hollywood hacking" sequences.  
+* **Mobile Responsive:** Looks great on desktop monitors and mobile devices.


### PR DESCRIPTION
### Description

**CyberTermX**, a dynamic, terminal-themed portfolio designed specifically for cybersecurity professionals, exploit developers, and bug bounty hunters. 

### Theme Overview

* **SSG:** Jekyll
* **CSS:** Tailwind CSS
* **Archetype:** Portfolio / Resume
* **Key Features:** 
  * Interactive web-based terminal with executable commands (`whoami`, `neofetch`, etc.).
  * 100% dynamic content managed via YAML files (no HTML editing required).
  * Dynamic RSS integration for pulling external blog posts.
  * Hacker aesthetics including a Matrix background, CRT scanlines, and hidden easter eggs.

Please let me know if any adjustments to the formatting or description are needed before merging. Thanks!